### PR TITLE
workaround for execution hook race condition

### DIFF
--- a/Restonite/RestoniteMod.cs
+++ b/Restonite/RestoniteMod.cs
@@ -64,7 +64,7 @@ namespace Restonite
             ResoniteHotReloadLib.HotReloader.RegisterForHotReload(this);
 #endif
 
-            Setup();
+            Engine.Current.OnReady += Setup;
         }
 
 #endregion


### PR DESCRIPTION
workaround for https://github.com/resonite-modding-group/ResoniteModLoader/issues/20

I haven't actually tested if it fixes it, but my intuition says it would. Due to it being a race condition it can be difficult to test it, easiest to replicate with Restonite being the only mod installed.